### PR TITLE
New HHVM compatibility (!!broken back-compatibility!!), added v8js allocator

### DIFF
--- a/src/v8js.cpp
+++ b/src/v8js.cpp
@@ -1,4 +1,5 @@
 #include "ext_v8js.h"
+#include "v8js_alloc.cpp"
 
 namespace HPHP
 {
@@ -85,6 +86,7 @@ namespace HPHP
         {
             return result->NumberValue();
         }
+        throw Exception(std::string("NoExecuteStringResultException"));
     }
 
     void v8jsExtension::_initV8JsClass() {
@@ -93,10 +95,12 @@ namespace HPHP
         v8::V8::InitializePlatform(platform);
         v8::V8::Initialize();
 
+        v8::V8::SetArrayBufferAllocator(new MallocArrayBufferAllocator);
+
         HHVM_ME(V8Js, __construct);
         HHVM_ME(V8Js, executeString);
 
-        Native::registerClassConstant<KindOfStaticString>(
+        Native::registerClassConstant<KindOfPersistentString>(
                 s_V8Js.get(), s_V8_VERSION.get(), String::FromCStr(v8::V8::GetVersion()).get()
         );
     }

--- a/src/v8js_alloc.cpp
+++ b/src/v8js_alloc.cpp
@@ -1,0 +1,6 @@
+class MallocArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+public:
+  virtual void* Allocate(size_t length) { return malloc(length); }
+  virtual void* AllocateUninitialized(size_t length) { return malloc(length); }
+  virtual void Free(void* data, size_t length) { free(data); }
+};


### PR DESCRIPTION
Fixed two issues:
1) In New HHVM engine KindOfStaticString replaced with KindOfPersistentString.
2) If no custom allocator used in v8js, segfault will thrown on v8 library with large JS files (BEM files, eq). I only added custom allocator.